### PR TITLE
Additional DevOps branch support

### DIFF
--- a/azure-pipelines-dotnet.yml
+++ b/azure-pipelines-dotnet.yml
@@ -4,7 +4,10 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
 
 trigger:
-- master
+  branches:
+  - master
+  - release/*
+  - hotfix/*
 
 pr: none
 


### PR DESCRIPTION
Add support for release and hotfix branches.  Useful in keeping the master branch with the primary jcoliz/yofi repo, while allowing pipeline releases via forked release-based branches with outside modified branches.