### PR TITLE
Move localdb support from PRD to DEV settings

### DIFF
--- a/YoFi.AspNet/appsettings.Development.json
+++ b/YoFi.AspNet/appsettings.Development.json
@@ -1,11 +1,14 @@
 ﻿{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-OfxWeb.Asp-BDDDDEB0-488C-4CEF-A390-529A80D08E0A;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
       "Default": "Debug",
       "System": "Information",
       "Microsoft": "Information",
-      "Microsoft.EntityFrameworkCore.Database.Command":  "Information"
+      "Microsoft.EntityFrameworkCore.Database.Command": "Information"
     }
   }
 }

--- a/YoFi.AspNet/appsettings.json
+++ b/YoFi.AspNet/appsettings.json
@@ -1,7 +1,4 @@
 ﻿{
-  "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-OfxWeb.Asp-BDDDDEB0-488C-4CEF-A390-529A80D08E0A;Trusted_Connection=True;MultipleActiveResultSets=true"
-  },
   "AzureStorage": {
     "DefaultEndpointsProtocol": "http"
   },


### PR DESCRIPTION
LocalDB is unsupported in Azure App Services and shouldn't normally be used with IIS.  Force a configuration decision when deploying to non-DEV.