### PR TITLE
test(int): Update to TestAdapter and TestFramework 2.2.9

### DIFF
--- a/YoFi.AspNet.Tests.Integration/YoFi.AspNet.Tests.Integration.csproj
+++ b/YoFi.AspNet.Tests.Integration/YoFi.AspNet.Tests.Integration.csproj
@@ -29,8 +29,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.9" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.9" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10-preview-20220414-01" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10-preview-20220414-01" />
     <PackageReference Include="AngleSharp" Version="0.16.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.3" />
   </ItemGroup>

--- a/YoFi.AspNet.Tests.Integration/YoFi.AspNet.Tests.Integration.csproj
+++ b/YoFi.AspNet.Tests.Integration/YoFi.AspNet.Tests.Integration.csproj
@@ -29,8 +29,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.9" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.9" />
     <PackageReference Include="AngleSharp" Version="0.16.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.3" />
   </ItemGroup>


### PR DESCRIPTION
This is expected to fail to run. Isolating in a branch to provide a
repro.